### PR TITLE
Remove shared-modules/libusb

### DIFF
--- a/com.js8call.JS8Call.yaml
+++ b/com.js8call.JS8Call.yaml
@@ -14,7 +14,6 @@ finish-args:
   - --socket=fallback-x11
 modules:
   - shared-modules/linux-audio/fftw3f.json
-  - shared-modules/libusb/libusb.json
 
   - name: hamlib
     sources:


### PR DESCRIPTION
It is already in the runtime.